### PR TITLE
Update to latest major release of Cassandra

### DIFF
--- a/lib/config/config.example.json
+++ b/lib/config/config.example.json
@@ -3,6 +3,7 @@
     "user": "cassandra",
     "password": "cassandra",
     "keyspace": "datastar",
-    "hosts": ["127.0.0.1"]
+    "hosts": ["127.0.0.1"],
+    "localDataCenter": "datacenter1"
   }
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -35,6 +35,7 @@ exports.load = function(env, callback) {
   function createKeyspace(data) {
     var client = new cassandra.Client({
       contactPoints: data.cassandra.hosts,
+      localDataCenter: data.cassandra.localDataCenter,
       authProvider: new cassandra.auth.PlainTextAuthProvider(
         data.cassandra.user,
         data.cassandra.password

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datastar-test-tools",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A toolkit for testing features of datastar",
   "main": "lib",
   "keywords": [
@@ -12,8 +12,8 @@
   "licenses": "MIT",
   "author": "GoDaddy Engineers",
   "dependencies": {
-    "datastar": "~1.1.0",
-    "cassandra-driver": "^3.0.2",
+    "cassandra-driver": "^4.1.0",
+    "datastar": "^1.7.0",
     "proxyquire": "^1.7.9",
     "read-only-stream": "^2.0.0",
     "through2": "^2.0.1"


### PR DESCRIPTION
`datastar` will require a version bump as the breaking change in the `cassandra-driver` is also a breaking change for the `datastar` wrapper.

The first step in this process is updating the `datastar-test-tools` library which is used to run the tests in the `datastar` library.

Local unit/integration test output via symlink:
```
> datastar@1.7.0 test /Users/scommisso/Projects/datastar
> npm run coverage


> datastar@1.7.0 coverage /Users/scommisso/Projects/datastar
> nyc npm run mocha


> datastar@1.7.0 mocha /Users/scommisso/Projects/datastar
> mocha -R spec test/



  Datastar
    ✓ should create datastar instance without pre-heating connection
    ✓ should create datastar instance with pre-heating connection

  Model
    Artist
      ✓ should create a model
      ✓ should create tables (83ms)
      ✓ should create
      ✓ should update (70ms)
      ✓ should find
      ✓ should remove (1020ms)
    update on List type
      ✓ create a person model (62ms)
      ✓ should create a person model with a list
      ✓ should handle an update operation that prepends a value on the list (1031ms)
      ✓ should handle an update for an append operation
      ✓ should handle an update for a remove operation
      ✓ should handle an update for an index operation
      ✓ should handle an update that replaces the list
      ✓ should fetch a person with the simpler find syntax (object)
      ✓ should fetch a person with the simpler find syntax (string)
      ✓ should completely remove the entity
    Composite Partition Keys
      ✓ should create the table when defining the model with composite partition key (56ms)
      ✓ should be able to create
      ✓ should be able to update that same record
      ✓ should error with simpler find syntax with more complicated key (string)
      ✓ should be able to find the record
      ✓ should error when updating without the hash in the composite key
      ✓ should error when we pass in a key that doesnt exist when running update
      ✓ should error when we pass in a key that doesnt exist when running create
      ✓ should remove the record
    Clustering Keys
      ✓ should create a table with secondary/clustering keys (57ms)
      ✓ should create an album with proper IDs
      ✓ should update an album
      ✓ should find an album
      ✓ should error when updating without the artistId
      ✓ should remove an Album
    Lookup Tables
      ✓ should be created when defining a model with lookupKeys and ensureTables is true (166ms)
      ✓ should be able to write all lookup tables
      ✓ should be able to update all lookup tables when not changing the primary keys
      ✓ should be able to find by all the `primaryKeys` and return the same value
      ✓ should be able to update to all lookup tables when changing a primaryKey for a lookup table and ensure the old primaryKey reference was deleted (515ms)
      ✓ should find all by all primaryKeys, specifically the new one and have equal values
      ✓ should properly update when not passing a previous value and doing a find operation to fetch previous state
      ✓ should fail to update when calling save on the model if no columns changed directly
      ✓ should update when calling save on the model and not call an extra findOne since we have the previous state
      ✓ should remove from all lookup tables
      ✓ should error when trying to remove without required attributes
    foo
      ✓ should create a table with an alter statement (57ms)
      ✓ should create multiple records in the database
      ✓ should create a record in the database that will properly expire with given ttl (3016ms)
      ✓ should create a record in the database that will expire but still be found before it reaches given ttl (3015ms)
      ✓ should update a record in the database that will expire with given ttl (2009ms)
      ✓ should update a record in the database that can be found before it reaches ttl (2017ms)
      ✓ should update a record in the database with an updated reset ttl and can be found before it reaches the updated ttl (5017ms)
      ✓ should update a record in the database with an updated reset ttl and expire after it reaches the updated ttl (3018ms)
      ✓ should run a find query with a limit of 1 and return 1 record
      ✓ should remove entities

  datastar-await-wrap
    ✓ should correctly wrap the create function
    ✓ should correctly wrap the update function
    ✓ should correctly wrap the remove function
    ✓ should correctly wrap the findOne function
    ✓ should correctly wrap the findAll function
    ✓ should return a stream from the findAllStream function
    ✓ should wrap ensureTables as the ensure function
    ✓ should wrap dropTables as the drop function

  Datastar (unit)
    ✓ should create datastar instance

  Model instance (unit)
    ✓ should "transform" data into an instance of the defined model
    json type handling
      ✓ should deserialize a json property
    Stringify an array, toJSON handling
      ✓ should contain the camelCase key when an array is stringified rather than snake_case
    #validate
      ✓ should validate the current data against the schema validation
      ✓ should return the validation error

  Model (unit)
    ✓ should create a model even with a missing name
    ✓ should create a model
    ✓ should create
    ✓ should error on create when no options are passed
    ✓ should be able to define a model with ensureTables option
    ✓ init() function should not call ensureTables if the ensureTables option is false
    ✓ init() function should call ensureTables if the ensureTables option is true
    - should be able to define a model with ensureTables option and error
    ✓ On find it should emit an error if passed bad fields and no callback
    ✓ should callback with an error if passed bad fields and a callback
    ✓ should error with an improper find type
    ✓ should find
    ✓ should find and return a stream if no callback is passed
    ✓ should run a count query
    ✓ should run a findFirst query
    ✓ should run a findOne query
    ✓ should remove a single entity

  Partial Statements
    with
      ✓ should return a with partial statement given appropriate options
      ✓ should return an error on the partial statement when it cannot process the given options

  Schema (unit)
    ✓ should create a schema
    ✓ should throw an error when given an invalid schema
    ✓ should throw an error when given an invalid name for the schema
    ✓ should transform the schema (snakecase and aliases)
    ✓ should validate the schema
    ✓ should allow for null values
    ✓ #fieldString() should return a list of all fields suitable for CQL consumption if no arguments are given
    ✓ #fieldString() should return a list of fields suitable for CQL consumption when a list of fields is given

  StatementBuilder
    FindStatement
      ✓ should return an find ALL statement if given an empty object or no options
      ✓ should return an find ALL statement with allow-filtering included
      ✓ should return an find statement with a field list if fields in options
      ✓ should return a find statement with a limit if specified in options
      ✓ should return an error when passed conditions that get filtered (non primary keys)
      ✓ should return a find statement with query params
    Lookup Tables
      ✓ (Find test) should return an error when passed conditions with conflicting lookup tables
      ✓ should return a valid statement that uses the proper lookup table for find when querying by domainName
      ✓ should return multiple statements to create for each lookup table
      ✓ should return a validation error when trying to create without all of the lookup tables
      ✓ should return multiple statements to delete from each lookup table
      ✓ should return an error when trying to delete with no conditions when there is a lookup table
      ✓ should return an error FOR NOW when trying to delete with insufficient conditions
      update
        ✓ should create a compound statement of compound statements with remove/create for looku tables
        ✓ should create a compound statement for lookup tables with 1 replacement for domain_name
    AlterStatement
      ✓ should return an error when given a bad type
      ✓ should return an error when given an unknown arg type
    TableStatment { schema } valid
      ✓ build()
      ✓ should return a proper TableStatement with orderBy option
      ✓ should return a proper TableStatement with orderBy option without order
      ✓ should return an error when given a bad key to orderBy
      ✓ should return a table statement with proper alterations
      ✓ should return a proper table statement with a schema that uses composite partition keys
      ✓ should return a proper table statement with a schema that uses a secondary or clustering key
      ✓ should return a proper TableStatement from _compile()
      ✓ should return a proper index TableStatement from _compile()
      ✓ should return a proper TableStatement from build()
      ✓ should return a proper index TableStatement from build()
      ✓ should return a proper TableStatement (lookup) from _compile()
      ✓ should return a proper index TableStatement (lookup) from _compile()
      ✓ should return a proper TableStatement (lookup) from build()
      ✓ should return a proper TableStatement for dropping the table from build()
      ✓ should return a proper TableStatement for dropping an index from build
      ✓ should return a proper index TableStatement (lookup) from build()
    RemoveStatement
      ✓ should return a proper RemoveStatement passed a single entity
      ✓ should return an error when passed an entity without a primary key
      ✓ should return an error when passed empty conditions 
      ✓ should return a proper RemoveStatement when passed a set of conditions
    UpdateStatement
      ✓ should return a proper update statement when given a artist object
      ✓ should return a proper statement with USING TTL if ttl options are passed
      ✓ should properly generate multiple statements when updating a set with add and remove
    CreateStatement
      ✓ should return a proper create statement when given a artist object
      ✓ should append USING TTL to the statement if it is passed as an option
      ✓ should return an error when given an improper entity


  138 passing (23s)
  1 pending

------------------------------------------|----------|----------|----------|----------|-------------------|
File                                      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------------------------------|----------|----------|----------|----------|-------------------|
All files                                 |    89.28 |     77.3 |    88.46 |    89.68 |                   |
 lib                                      |    88.81 |    75.38 |    87.95 |     89.4 |                   |
  attributes.js                           |    93.88 |    77.27 |       90 |    95.65 |             48,53 |
  await-wrap.js                           |    73.33 |      100 |    69.23 |    73.33 |    66,104,123,131 |
  index.js                                |     87.5 |    65.71 |      100 |     87.5 |... 07,108,116,119 |
  model.js                                |    86.04 |    72.67 |     81.4 |     87.1 |... 31,644,657,667 |
  schema.js                               |    89.89 |    78.02 |    91.76 |    90.24 |... 1123,1125,1127 |
  statement-collection.js                 |    96.97 |    81.25 |      100 |    96.97 |                39 |
 lib/statement-builder                    |    96.67 |    70.83 |    83.33 |    96.67 |                   |
  compound-statement.js                   |      100 |       50 |       75 |      100 |                24 |
  index.js                                |    94.12 |    78.57 |      100 |    94.12 |             89,90 |
  statement.js                            |      100 |    66.67 |       75 |      100 |                39 |
 lib/statement-builder/partial-statements |    97.22 |    93.75 |      100 |    97.14 |                   |
  with.js                                 |    97.22 |    93.75 |      100 |    97.14 |                22 |
 lib/statement-builder/statements         |    88.35 |    80.31 |     89.8 |     88.5 |                   |
  alter.js                                |    62.16 |    63.64 |       60 |    61.11 |... 78,80,82,83,86 |
  create.js                               |    95.83 |       90 |      100 |    95.65 |                20 |
  find.js                                 |    93.75 |    93.75 |       80 |    93.75 |        63,102,103 |
  index.js                                |      100 |      100 |      100 |      100 |                   |
  remove.js                               |    95.65 |     87.5 |      100 |    95.65 |                24 |
  table.js                                |    95.18 |    88.71 |      100 |     96.2 |         51,77,131 |
  update.js                               |    86.91 |    74.17 |       92 |    87.03 |... 67,571,575,604 |
------------------------------------------|----------|----------|----------|----------|-------------------|
scommisso at LMTC-SCOMM in ~/Projects/datastar on master*
```